### PR TITLE
Make sample object explicitly public-read

### DIFF
--- a/s3_sample.rb
+++ b/s3_sample.rb
@@ -47,8 +47,11 @@ bucket.create
 #
 # For more information on Aws::S3::Object#put, see:
 # http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#put-instance_method 
-object = bucket.object('ruby_sample_key.txt')
-object.put(body: "Hello World!")
+object = bucket.put_object({
+  acl: "public-read",
+  body: "Hello World!",
+  key: "ruby_sample_key.txt" # required
+})
 
 # Aws::S3::Object#public_url generates an un-authenticated URL for the object.
 # 


### PR DESCRIPTION
*Issue #, if available:*
Access denied on sample s3 object when trying to view.

*Description of changes:*
Explicitly use `acl: "public-read"` via `#put_object` notation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
